### PR TITLE
Show note about Ipopt timing in RTD Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .tox/
 
+.coverage
 /env*/
 /dist/
 venv*/

--- a/docs/user_guide/conf.py
+++ b/docs/user_guide/conf.py
@@ -28,6 +28,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
+    "sphinx.ext.ifconfig",
     "sphinxcontrib.bibtex",
     "sphinx_copybutton",
     "nbsphinx",
@@ -43,6 +44,14 @@ intersphinx_mapping = {
 }
 
 copybutton_exclude = ".linenos, .gp"
+
+# inject environment variable READTHEDOCS into notebook environment
+on_rtd = os.environ.get("READTHEDOCS") == "True"
+nbsphinx_execute_arguments = [
+    "--InlineBackend.figure_formats={'svg'}",
+    "--InlineBackend.rc={'figure.dpi': 96}",
+    f"--os.environ['READTHEDOCS']={on_rtd}",
+]
 
 autosummary_generate = True
 add_module_names = False
@@ -88,7 +97,10 @@ bibtex_bibfiles = ["references.bib"]
 
 
 def setup(app):
+    # run makefiles to generate content
     app.connect("config-inited", run_makefiles)
+    # flag for conditional content if building on ReadTheDocs
+    app.add_config_value("on_rtd", on_rtd, "html")
 
 
 def run_makefiles(_app, _config):

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -157,6 +157,16 @@ notebooks/index.rst
 scripts/index.rst
 ```
 
+```{eval-rst}
+.. ifconfig:: on_rtd
+
+.. note::
+
+   The solutions presented in this documentation were computed as part of the
+   documentation build on Read the Docs, and the solutions times are likely not
+   representative of the actual solution times required on your machine.
+```
+
 ```{toctree}
 :caption: Project Information
 :maxdepth: 1

--- a/examples/notebooks/delta_iii_ascent.ipynb
+++ b/examples/notebooks/delta_iii_ascent.ipynb
@@ -210,7 +210,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "bb81a568-2937-484a-9eee-55f2efd00c46",
+      "id": "f8f7bc0a-9260-4646-93b9-44afb47c8d4c",
       "metadata": {
         "editable": true,
         "slideshow": {
@@ -945,7 +945,7 @@
         "\n",
         "    Most likely, the evaluation of the above cell produced a warning:\n",
         "\n",
-        "    .. code-block:: console\n",
+        "    .. code-block:: text\n",
         "\n",
         "        RuntimeWarning: invalid value encountered in divide mu_over_r3 = mu / r**3\n",
         "    \n",

--- a/src/yapss/examples/isoperimetric.py
+++ b/src/yapss/examples/isoperimetric.py
@@ -128,7 +128,7 @@ def main() -> None:
     # print the solution
     area = solution.objective
     area_ideal = 1 / (4 * math.pi)
-    print(f"\n\nMaximum area = {area} (Should be 1 / (4 pi) = {area_ideal})")
+    print(f"\nMaximum area = {area} (Should be 1 / (4 pi) = {area_ideal})")
     print(f"Relative error in solution = {abs(area - area_ideal) / area_ideal}")
 
     # plot the solution


### PR DESCRIPTION
## Description

In the Read the Docs documentation, the JupyterLab and Python script examples print out timing information with the Ipopt output. In some cases, the time to run is a factor of 10 higher than if the example is run on a local machine. The problem is probably due to the speed of the RTD servers. In any event, it's misleading.

This commit has three modifications:

1. In solver.py, a function `print_rtd_note` is called that prints out a note if the environment variable `READTHEDOCS == "True"`, that appears just below the Ipopt timing data.

2. In conf.py, the `READTHEDOCS` variable is injected into the JupyterLab notebooks to trigger the same behavior in notebooks as in scripts. Also, a configuration values, `on_rtd`, is defined that allows conditional content in sphinx documents using the `inconfig` directive.

3. A (conditional) note about this issue was placed on the main index page in the Examples section.

## Type of change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] `export READTHEDOCS=TRUE` and `make view-docs` produces a user guide that shows the conditional
    material and note following Ipopt output properly.
- [x] `export READTHEDOCS=` and `make view-docs` produces the same output as before this commit.

**Test Configuration**:

* Operating System: MacOS
* Hardware: M! MacBook

## Checklist:

- [x] My code changes are consistent with the style of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules