### PR TITLE
[Bugfix] Fix numpy 2.5 incompatibility and update mypy typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,12 @@ repos:
         args: [ "--check-only" ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.0
+    rev: v1.20.2
     hooks:
       - id: mypy
-        language_version: python3.10
+        language_version: python3.13
         additional_dependencies:
-          - numpy<2.0.0
+          - numpy==2.4.6
           - types-toml
         entry: bash -c "cd src && mypy yapss --config-file ../pyproject.toml"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,28 @@ considered stable. YAPSS will follow a predictable versioning policy during 0.x 
 - Users can pin to a specific minor version (e.g., yapss>=0.3.0,<0.4.0) to avoid unexpected 
   changes, but should expect significant updates when upgrading to a new minor version.
 
-<!-- 
 ## [Unreleased]
 
-### Added
+### Fixed
+
+- Fixed the root cause of the NumPy 2.5 import failure (previously only worked around via
+  a `numpy<2.5` ceiling in 0.1.1). NumPy 2.5 rewrote `numpy.typing.NDArray` using PEP 695
+  `type` statements, which cannot be subclassed directly; `ContinuousArray` now subclasses
+  `np.ndarray` directly instead. The `numpy<2.5` ceiling remains for now because NumPy 2.5
+  requires Python 3.12+, which conflicts with YAPSS's `>=3.10` support — raising the floor
+  is deferred to a future release.
 
 ### Changed
 
-### Fixed
--->
+- Advanced the `mypy` dev/CI tooling from 1.13.0 to 1.20.2, and its `numpy` constraint from
+  `<2.0.0` to an exact `2.4.6` pin. Also moved the `mypy` tox environment's `basepython` from
+  Python 3.10 to 3.13 to match the pre-commit hook, since NumPy dropped Python 3.10 wheels
+  entirely as of 2.4.6 was unreachable from a 3.10-hosted environment (it caps at 2.2.6). No
+  user-facing effect; `[tool.mypy] python_version = "3.10"` still governs the actual
+  type-checking target regardless of which Python hosts the checker.
+- Switched `plt.xlim(...)`/`plt.ylim(...)` calls in the example scripts from list to tuple
+  arguments (e.g. `plt.xlim([0, 1])` → `plt.xlim((0, 1))`), matching matplotlib's type stubs.
+  No behavior change.
 
 ---
 

--- a/development/RELEASE_CHECKLIST.md
+++ b/development/RELEASE_CHECKLIST.md
@@ -33,7 +33,7 @@ it belongs here.
       backend, supported Python range, etc.), say so explicitly — it's the
       difference that generates confusing bug reports.
 
-## 3. Documentation review
+## 3. Documentation review (local build)
 
 Do this *before* tagging — it's much cheaper to fix docs pre-release than to
 carry a stale RTD-published version forward (RTD builds each version from its
@@ -58,13 +58,6 @@ policy).
       not documented is easy to miss until a user hits it.
 - [ ] Run `make readme` after any `docs/user_guide/index.md` edits, and
       commit the regenerated `README.md` alongside.
-- [ ] Once pushed, trigger a trial build on Read the Docs itself for the
-      release branch (not just local `make docs`/tox) and confirm it's
-      clean. RTD's real environment differs from local in ways that matter
-      (real internet access for intersphinx, its own pinned toolchain) —
-      requires Steve's own RTD admin access, can't be done from this
-      environment. This is a pre-merge sanity check, distinct from the
-      post-publish `stable`-resolves-correctly check in §8.
 
 ## 4. CI
 
@@ -73,25 +66,70 @@ policy).
       `workflow_dispatch` run of the conda test job.
 - [ ] Before merging a branch that changes workflow trigger config (`on:`
       blocks), validate with a manual `workflow_dispatch` run *from that
-      branch* rather than trusting the PR's own check run. GitHub only runs a
-      `pull_request`-triggered workflow reliably once that trigger already
-      exists on the default branch — a brand-new trigger on a feature branch
-      is not reliable on the PR's own checks.
-- [ ] Merge to `main`. Confirm CI is green on `main` itself (a fresh `push`
-      event on the real trigger config, not just the branch's).
+      branch* as a belt-and-suspenders check. Confirmed on the v0.1.1 PR:
+      GitHub reliably picks up trigger changes on the PR's own checks as long
+      as the workflow *file* already exists on the default branch — the risk
+      case is a workflow file that's entirely new to the repo, which won't
+      fire on `pull_request` until it's merged.
 
-## 5. Build verification
+## 5. RTD build (hosted)
 
-- [ ] Verify the built wheel in a clean venv:
-      `pip install dist/*.whl && python -m yapss.examples.isoperimetric`
+- [ ] Once CI is green, trigger a trial build on Read the Docs itself for the
+      release branch/PR (not just local `make docs`/tox) and confirm it's
+      clean. RTD's real environment differs from local in ways that matter
+      (real internet access for intersphinx, its own pinned toolchain) —
+      requires Steve's own RTD admin access, can't be done from this
+      environment. This is a pre-merge sanity check, distinct from the
+      post-publish `stable`-resolves-correctly check in §10.
 
-## 6. Tag & publish
+## 6. Build verification
+
+Build from a fresh `git clone` of the release branch into a temp dir, not the
+local working tree — a local build can hide files that aren't actually
+tracked in git (missing from packaging config) or stale artifacts left over
+from previous builds/editable installs.
+
+- [ ] Clean build in a clean environment:
+      ```
+      git clone https://github.com/stevenrhall/yapss /tmp/yapss-build-check
+      cd /tmp/yapss-build-check && git checkout <release-branch>
+      python -m venv .venv && source .venv/bin/activate
+      pip install build
+      python -m build
+      pip install dist/*.whl
+      python -m yapss.examples.isoperimetric
+      ```
+- [ ] Spot-check the sdist and wheel file listings (`tar tzf dist/*.tar.gz` /
+      `unzip -l dist/*.whl`) for missing package data or accidentally-included
+      dev/test cruft.
+
+## 7. Merge to main
+
+YAPSS uses a PR-into-`main`-then-tag model — no dedicated release branch.
+`hatch-vcs` derives the published version from the tag, and a single `main` +
+tags is simpler than maintaining release branches, which would only earn
+their keep if YAPSS needed to maintain multiple release lines in parallel
+(e.g. hotfixing an old minor after a newer one shipped) — not a current need.
+
+- [ ] Open a PR from the release branch into `main` (don't push directly) —
+      this exercises CI and the RTD PR-preview build (§4, §5) against the
+      actual merge target.
+- [ ] Squash merge, with a commit message drawn from the PR description or
+      `CHANGELOG.md` entry rather than GitHub's default (which concatenates
+      every commit subject from the branch).
+- [ ] Delete the head branch after merge — safe to do; the squashed commit is
+      already permanent in `main`'s history, and the PR page retains the full
+      pre-squash commit history regardless.
+- [ ] Confirm CI is green on `main` itself (a fresh `push` event on the real
+      trigger config, not just the branch's).
+
+## 8. Tag & publish
 
 - [ ] Tag `vX.Y.Z` and push. `hatch-vcs` derives the version from the tag.
 - [ ] Publish to PyPI — prefer trusted publishing (OIDC) over a stored API
       token.
 
-## 7. Conda
+## 9. Conda
 
 - [ ] Wait for the conda-forge autotick bot PR (hours, not immediate). It
       updates version and sha256 and resets the build number to 0, but does
@@ -102,7 +140,7 @@ policy).
 - [ ] Verify: `conda create -n check -c conda-forge yapss`, then run the
       isoperimetric example.
 
-## 8. Post-publish docs checks
+## 10. Post-publish docs checks
 
 - [ ] Confirm `stable` on Read the Docs resolves to the new version (RTD
       picks the highest semver tag by default, but check it wasn't manually

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,12 @@ dependencies = [
     # tested. Revisit once mseipopt is no longer the default solver backend.
     "casadi>=3.6.0,<=3.7.2",
     "scipy",
-    # TODO: Remove temporary NumPy upper bound after NumPy 2.5 compatibility work.
+    # NumPy 2.5 rewrote numpy.typing.NDArray using PEP 695 `type` statements, which
+    # broke subclassing it directly -- fixed in _private/input_args.py (now
+    # version-agnostic, subclasses np.ndarray directly). Ceiling stays for now:
+    # numpy>=2.5 requires Python>=3.12, which conflicts with requires-python
+    # ">=3.10" -- raising this floor needs its own follow-up (env markers or
+    # dropping 3.10/3.11 support), not bundled into this typing fix.
     "numpy<2.5",
     "mpmath",
     "matplotlib",
@@ -115,7 +120,8 @@ packages = ["src/yapss"]
 python_version = "3.10"
 files = ["src/**/*.py"]
 follow_imports = "silent"
-plugins = "numpy.typing.mypy_plugin"
+# numpy.typing.mypy_plugin removed -- deprecated as of NumPy 2.3, will be
+# removed entirely in a future NumPy release.
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
 namespace_packages = true
 warn_redundant_casts = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,10 @@ dev = [
     "pyyaml",
     "hatch",
     "pre-commit",
+    # release tooling -- used by `make test-pypi-upload`/`pypi-upload` and
+    # RELEASE_CHECKLIST.md's build-verification step
+    "build",
+    "twine",
 ]
 
 [project.urls]

--- a/src/yapss/_private/central_difference.py
+++ b/src/yapss/_private/central_difference.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     # package imports
     import yapss
 
-    from .problem import Scale
+    from .problem import Problem, Scale
     from .types_ import CHFDS, CJFDS, DHFDS, DJFDS, OGS, DVKey
 
     Array = NDArray[np.float64]
@@ -119,14 +119,14 @@ def make_cd_functions(problem: yapss.Problem, z0: Array) -> ProblemFunctions:
 
 
 def make_objective_gradient(
-    problem: yapss._private.problem.Problem,
+    problem: Problem,
     ogs: OGS,
 ) -> ObjectiveGradientFunction:
     """Generate objective gradient callback function using finite differences.
 
     Parameters
     ----------
-    problem : yapss._private.problem.Problem
+    problem : Problem
         The user-defined problem object
     ogs : OGS
         Finite difference structure for the objective gradient.

--- a/src/yapss/_private/guess.py
+++ b/src/yapss/_private/guess.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     # package imports
     import yapss
 
+    from .mesh import Mesh
     from .problem import Problem
     from .solution import Solution
 
@@ -295,7 +296,7 @@ class PhaseGuess(Protected):
             raise ValueError(msg)
 
 
-def make_initial_guess_nlp(problem: Problem, computational_mesh: yapss._private.mesh.Mesh) -> Array:
+def make_initial_guess_nlp(problem: Problem, computational_mesh: Mesh) -> Array:
     """Make initial guess for the NLP solution from the user-provided initial guess.
 
     This method takes the initial guess provided by the user and interpolates to produce an

--- a/src/yapss/_private/input_args.py
+++ b/src/yapss/_private/input_args.py
@@ -153,17 +153,17 @@ class DiscretePhase(Generic[T]):
     @property
     def initial_state(self) -> NDArray[T]:
         """Initial state of the phase as an immutable copy."""
-        return self._initial_state.copy()
+        return cast(NDArray[T], self._initial_state.copy())
 
     @property
     def final_state(self) -> NDArray[T]:
         """Final state of the phase as an immutable copy."""
-        return self._final_state.copy()
+        return cast(NDArray[T], self._final_state.copy())
 
     @property
     def integral(self) -> NDArray[T]:
         """Array of integral values for the phase as an immutable copy."""
-        return self._integral.copy()
+        return cast(NDArray[T], self._integral.copy())
 
 
 class ObjectiveArg(DiscreteArgBase[T], Protected, Generic[T]):
@@ -285,7 +285,7 @@ class DiscreteArg(DiscreteArgBase[T], Protected, Generic[T]):
         return self._discrete
 
     @discrete.setter
-    def discrete(self, value: Sequence[Any]) -> None:
+    def discrete(self, value: NDArray[T] | Sequence[Any]) -> None:
         """Set the discrete array."""
         self._discrete[:] = value
 
@@ -514,16 +514,22 @@ class ContinuousPhase(Protected, Generic[T]):
         return self._hessian
 
 
-class ContinuousArray(NDArray[T], Generic[T]):
+class ContinuousArray(np.ndarray[Any, np.dtype[T]], Generic[T]):
     """Custom continuous array that initializes with zeros and handles assignment."""
 
     def __new__(cls, shape: list[int], dtype: type[T], **kwargs: Any) -> ContinuousArray[T]:
         # Create an instance of ContinuousArray with the specified dtype
         obj = super().__new__(cls, shape, dtype=dtype, **kwargs)
         obj.fill(0)  # Initialize with zeros or appropriate type
-        return obj
+        return cast(ContinuousArray[T], obj)
 
-    def __setitem__(self, item: slice | int, value: Any) -> None:
+    # Deliberately narrower than ndarray's real overloaded __setitem__ (this
+    # subclass only ever needs slice/int indexing with scalar-expansion below).
+    def __setitem__(  # type: ignore[override]
+        self,
+        item: slice | int,
+        value: Any,
+    ) -> None:
         """Set item in array, expanding scalar values to match the shape if needed."""
         # If the value is an iterable, expand each element to match the shape
         if isinstance(value, (list, tuple)):

--- a/src/yapss/_private/nlp.py
+++ b/src/yapss/_private/nlp.py
@@ -86,7 +86,7 @@ class NLP:
         self,
         problem: yapss.Problem,
         functions: ProblemFunctions,
-        mesh: yapss._private.mesh.Mesh,
+        mesh: Mesh,
     ) -> None:
         # store arguments
         self.problem: yapss.Problem = problem
@@ -446,7 +446,8 @@ def make_nlp_constraints(nlp: NLP) -> Callable[[FloatArray], FloatArray]:
             discrete_function(di)
             cf.discrete[:] = di.discrete
 
-        return cf.c.copy()
+        result: FloatArray = cf.c.copy()
+        return result
 
     # end callback function
 

--- a/src/yapss/_private/quadrature.py
+++ b/src/yapss/_private/quadrature.py
@@ -16,20 +16,26 @@ from __future__ import annotations
 __all__ = ["lgl", "lgr"]
 
 # standard imports
-from collections.abc import Callable
 from functools import wraps
+from typing import TYPE_CHECKING
 
 # third party imports
 import mpmath
 import numpy as np
 from mpmath import mp
-from numpy.typing import NDArray
 
-# typing
-Array = NDArray[np.float64]
-MPArray = NDArray[np.object_]
+if TYPE_CHECKING:
+    # standard imports
+    from collections.abc import Callable
 
-LG_func = Callable[[int], tuple[Array, ...]]
+    # third party imports
+    from numpy.typing import NDArray
+
+    # typing
+    Array = NDArray[np.float64]
+    MPArray = NDArray[np.object_]
+
+    LG_func = Callable[[int], tuple[Array, ...]]
 
 mp.dps = 30
 

--- a/src/yapss/_private/solution.py
+++ b/src/yapss/_private/solution.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     import yapss
 
+    from .mesh import Mesh
     from .nlp import NLP
 
 __all__ = ["NLPInfo", "Solution", "SolutionPhase", "SolutionPhases", "make_solution_object"]
@@ -60,7 +61,7 @@ _dataclass_msg = "All attributes must be provided, and cannot be None"
 
 def make_solution_object(
     problem: yapss.Problem,
-    mesh: yapss._private.mesh.Mesh,
+    mesh: Mesh,
     nlp_temp: NLP,
     nlp_info: dict[str, NDArray[np.float64] | float | int | bytes],
 ) -> Solution:

--- a/src/yapss/examples/brachistochrone.py
+++ b/src/yapss/examples/brachistochrone.py
@@ -157,8 +157,8 @@ def plot_solution(solution: Solution, *, wall: bool = False) -> None:
     plt.plot(x, y, linewidth=lw)
     plt.xlabel("$x(t)$")
     plt.ylabel("$y(t)$")
-    plt.xlim([-0.05, 1.05])
-    plt.ylim([0.7, -0.05])
+    plt.xlim((-0.05, 1.05))
+    plt.ylim((0.7, -0.05))
     plt.axis("scaled")
     if wall:
         plt.legend(("Wall", "Trajectory"), framealpha=1.0)
@@ -171,7 +171,7 @@ def plot_solution(solution: Solution, *, wall: bool = False) -> None:
     plt.xlabel("Time, $t$")
     plt.ylabel("States")
     plt.legend(("$x(t)$", "$y(t)$", "$v(t)$"), framealpha=1.0)
-    plt.xlim([t0, tf])
+    plt.xlim((t0, tf))
 
     # control
     plt.figure(3)
@@ -179,14 +179,14 @@ def plot_solution(solution: Solution, *, wall: bool = False) -> None:
     plt.plot(time_c, control[0], linewidth=lw)
     plt.xlabel("Time, $t$ [s]")
     plt.ylabel("Control, $u(t)$ [rad]")
-    plt.ylim([-0.05, 1.6])
-    plt.xlim([t0, tf])
+    plt.ylim((-0.05, 1.6))
+    plt.xlim((t0, tf))
 
     # costates
     plt.figure(4)
     plt.clf()
     plt.plot(time_c, costate[0], time_c, costate[1], time_c, costate[2])
-    plt.xlim([t0, tf])
+    plt.xlim((t0, tf))
     plt.xlabel("Time, $t$")
     plt.ylabel(r"Costates, $p_{i}$")
     plt.legend(["costate 0", "costate 1", "costate 2"], framealpha=1.0)
@@ -195,8 +195,8 @@ def plot_solution(solution: Solution, *, wall: bool = False) -> None:
     plt.figure(5)
     plt.clf()
     plt.plot(time_c, hamiltonian)
-    plt.xlim([t0, tf])
-    plt.ylim([-1.01, -0.99])
+    plt.xlim((t0, tf))
+    plt.ylim((-1.01, -0.99))
     plt.xlabel("Time, $t$")
     plt.ylabel(r"Hamiltonian, $\mathcal{H}$")
 

--- a/src/yapss/examples/brachistochrone_minimal.py
+++ b/src/yapss/examples/brachistochrone_minimal.py
@@ -80,8 +80,8 @@ def plot_solution(solution: Solution) -> None:
     plt.xlabel("Horizontal position, $x(t)$")
     plt.ylabel("Vertical position, $y(t)$")
     plt.grid()
-    plt.xlim([0.0, 1.0])
-    plt.ylim([0.8, -0.1])
+    plt.xlim((0.0, 1.0))
+    plt.ylim((0.8, -0.1))
     plt.axis("scaled")
     plt.tight_layout()
 

--- a/src/yapss/examples/delta_iii_ascent.py
+++ b/src/yapss/examples/delta_iii_ascent.py
@@ -497,7 +497,7 @@ def plot_solution(solution: Solution) -> None:
     for p in range(4):
         plt.plot(t[p], x[p][6])
     plt.ylabel("Vehicle mass, $m$ (kg)")
-    plt.ylim([0, 300000])
+    plt.ylim((0, 300000))
 
     # control vector
     plt.figure(2)
@@ -505,7 +505,7 @@ def plot_solution(solution: Solution) -> None:
         for i in range(3):
             plt.plot(tu[p], u[p][i], color[i])
     plt.ylabel("Components of thrust direction vector, $u(t)$")
-    plt.ylim([-0.8, 1.0])
+    plt.ylim((-0.8, 1.0))
 
     # velocity vector
     plt.figure(3)
@@ -519,7 +519,7 @@ def plot_solution(solution: Solution) -> None:
     for phase in range(4):
         plt.plot(t[phase], v[phase], color[0])
     plt.ylabel("Magnitude of inertial velocity, $v(t)$ (m/s)")
-    plt.ylim([0, 12000])
+    plt.ylim((0, 12000))
 
     # position vector
     plt.figure(5)
@@ -547,7 +547,7 @@ def plot_solution(solution: Solution) -> None:
     # common figure elements
     for i in range(1, 8):
         plt.figure(i)
-        plt.xlim([0, 1000])
+        plt.xlim((0, 1000))
         plt.xlabel("Time, $t$ (s)")
         plt.grid(visible=True)
         plt.tight_layout()

--- a/src/yapss/examples/dynamic_soaring.py
+++ b/src/yapss/examples/dynamic_soaring.py
@@ -193,7 +193,7 @@ def plot_solution(solution: Solution) -> None:
     limit = 5 * (auxdata.m * auxdata.g0) / (0.5 * auxdata.rho0 * auxdata.s * v**2)
     plt.plot(t, limit, "r--")
     plt.plot(tc, cl)
-    plt.ylim([0, 1])
+    plt.ylim((0, 1))
     legend = plt.legend(["Load factor limit", "Lift coefficient, $C_{L}$"])
     legend.get_frame().set_facecolor("white")
     legend.get_frame().set_alpha(1)
@@ -224,7 +224,7 @@ def plot_solution(solution: Solution) -> None:
     plt.figure(7)
     plt.plot(tc, hamiltonian)
     plt.ylabel(r"Hamiltonian, $\mathcal{H}$")
-    plt.ylim([-0.01, 0.01])
+    plt.ylim((-0.01, 0.01))
 
     for i in range(2, 8):
         plt.figure(i)

--- a/src/yapss/examples/goddard_problem_1_phase.py
+++ b/src/yapss/examples/goddard_problem_1_phase.py
@@ -212,7 +212,7 @@ def plot_solution(solution: Solution) -> None:
     for i in range(1, 6):
         plt.figure(i)
         plt.xlabel("Time, $t$ (sec)")
-        plt.xlim([t0, tf])
+        plt.xlim((t0, tf))
         plt.tight_layout()
         plt.grid()
 

--- a/src/yapss/examples/goddard_problem_3_phase.py
+++ b/src/yapss/examples/goddard_problem_3_phase.py
@@ -318,14 +318,14 @@ def plot_solution(solution: Solution) -> None:
         hamiltonian = sum(dynamics[p][i] * costate[p][i] for i in range(3))
         line1 = ax.plot(time_c[p], hamiltonian)
         line.append(line1)
-    plt.ylim([-0.01, 0.01])
+    plt.ylim((-0.01, 0.01))
     plt.ylabel(r"Hamiltonian, $\mathcal{H}")
 
     for i in range(1, 6):
         plt.figure(i)
         plt.legend(("Phase 1", "Phase 2", "Phase 3"), framealpha=1.0)
         plt.xlabel("Time, $t$ (sec)")
-        plt.xlim([t0, tf])
+        plt.xlim((t0, tf))
         plt.tight_layout()
         plt.grid()
 

--- a/src/yapss/examples/minimum_time_to_climb.py
+++ b/src/yapss/examples/minimum_time_to_climb.py
@@ -374,8 +374,8 @@ def plot_density() -> None:
     plt.plot(get_rho(h), h)
     plt.xlabel(r"Density, $\rho$ (slug/ft$^3$)")
     plt.ylabel(r"Altitude, $h$ (ft)")
-    plt.xlim([0.0, 0.0025])
-    plt.ylim([0.0, 70000.0])
+    plt.xlim((0.0, 0.0025))
+    plt.ylim((0.0, 70000.0))
     plt.grid()
 
 
@@ -385,8 +385,8 @@ def plot_speed_of_sound() -> None:
     plt.plot(get_c(h), h)
     plt.xlabel(r"Speed of sound, $c$ (m/s)")
     plt.ylabel(r"Altitude, $h$ (ft)")
-    plt.xlim([960.0, 1120.0])
-    plt.ylim([0.0, 70000.0])
+    plt.xlim((960.0, 1120.0))
+    plt.ylim((0.0, 70000.0))
     plt.grid()
 
 
@@ -397,8 +397,8 @@ def plot_lift_curve_slope() -> None:
     plt.plot(mach_cla, cla, ".", markersize=10)
     plt.ylabel(r"Lift curve slope, $C_{L_{\alpha}}$")
     plt.xlabel(r"Mach number, $M$")
-    plt.xlim([0.0, 1.8])
-    plt.ylim([2, 5])
+    plt.xlim((0.0, 1.8))
+    plt.ylim((2, 5))
     plt.grid()
 
 
@@ -409,8 +409,8 @@ def plot_cd0() -> None:
     plt.plot(mach_cd0, cd0, ".", markersize=10)
     plt.ylabel(r"Baseline drag coefficient, $C_{D_{0}}$")
     plt.xlabel(r"Mach number, $M$")
-    plt.xlim([0.0, 1.8])
-    plt.ylim([0.01, 0.045])
+    plt.xlim((0.0, 1.8))
+    plt.ylim((0.01, 0.045))
     plt.grid()
 
 
@@ -421,8 +421,8 @@ def plot_eta() -> None:
     plt.plot(mach_eta, eta_data, ".", markersize=10)
     plt.ylabel(r"Induced drag coefficient, $\eta$")
     plt.xlabel(r"Mach number, $M$")
-    plt.xlim([0.0, 1.8])
-    plt.ylim([0.5, 0.95])
+    plt.xlim((0.0, 1.8))
+    plt.ylim((0.5, 0.95))
     plt.grid()
 
 

--- a/src/yapss/examples/newton.py
+++ b/src/yapss/examples/newton.py
@@ -209,8 +209,8 @@ def plot_solution(solution: Solution) -> None:
     # plot
     plt.plot(r, y, "r", linewidth=linewidth)
     plt.axis("equal")
-    plt.xlim([-1, 1])
-    plt.ylim([-0.1, 2.1])
+    plt.xlim((-1, 1))
+    plt.ylim((-0.1, 2.1))
     plt.xlabel("Radius, $r/R$")
     plt.ylabel("Height, $y/R$")
     plt.tight_layout()

--- a/src/yapss/examples/orbit_raising.py
+++ b/src/yapss/examples/orbit_raising.py
@@ -156,7 +156,7 @@ def plot_solution(solution: Solution) -> None:
     plt.plot(t, theta, label=r"polar angle, $\theta$")
     plt.plot(t, v_r, label=r"radial velocity, $v_r$")
     plt.plot(t, v_theta, label=r"tangential velocity, $v_\theta$")
-    plt.ylim([0, 2.5])
+    plt.ylim((0, 2.5))
     plt.ylabel("States")
     plt.legend()
 
@@ -166,7 +166,7 @@ def plot_solution(solution: Solution) -> None:
     plt.plot(tc, control[1], label=r"tangential thrust, $u_2$")
     plt.ylabel("Controls")
     plt.legend()
-    plt.ylim([-1, 1])
+    plt.ylim((-1, 1))
 
     # figure 3: Thrust direction
     plt.figure(3)
@@ -206,7 +206,7 @@ def plot_solution(solution: Solution) -> None:
     hamiltonian = solution.phase[0].hamiltonian
     plt.plot(tc, hamiltonian)
     plt.ylabel(r"Hamiltonian, $\mathcal{H}$")
-    plt.ylim([-0.36, -0.31])
+    plt.ylim((-0.36, -0.31))
 
     for i in range(5, 0, -1):
         plt.figure(i)

--- a/tox.ini
+++ b/tox.ini
@@ -86,14 +86,28 @@ deps =
 commands =
     isort --check-only src examples/notebooks tests
 
-# TODO: NumPy's improved type hints (2.2+) trip mypy. This env is pinned two
-# major versions behind the test envs; revisit alongside the <2.5 ceiling.
+# Advanced mypy's numpy dependency from <2.0.0 (two generations stale) towards
+# 2.4.x. `python_version = "3.10"` in [tool.mypy] (pyproject.toml) still governs
+# the actual type-checking target/syntax semantics, independent of the host
+# below -- so raising basepython does NOT relax which Python version the code is
+# checked for compatibility with. Raising the numpy ceiling itself past 2.5 is a
+# separate, deferred decision (numpy 2.5 needs Python 3.12+ at runtime, which
+# conflicts with requires-python -- see pyproject.toml's numpy pin).
+#
+# numpy is pinned to an EXACT version here (like mypy is), not just <2.5: numpy's
+# generic ndarray typing (e.g. the return type of `.copy()`) has genuinely
+# different mypy-visible behavior across numpy point releases. basepython is set
+# to python3.13 (not 3.10) because numpy dropped Python 3.10 wheels entirely as
+# of 2.3.0 -- a 3.10-hosted env can never resolve past numpy 2.2.6, no matter
+# what upper bound is set here. Keep this numpy pin in sync with the mypy hook's
+# additional_dependencies in .pre-commit-config.yaml (which already used
+# python3.13 for the same reason).
 [testenv:mypy]
-basepython = python3.10
+basepython = python3.13
 deps =
     lxml
-    mypy==1.13.0
-    numpy<2.0.0
+    mypy==1.20.2
+    numpy==2.4.6
     types-toml
 commands =
     mypy src/yapss


### PR DESCRIPTION
# Fix numpy 2.5 incompatibility and update mypy typing - #4

## Description

Fixes a NumPy 2.5 import break and unifies the mypy tooling environment.

- Root cause: NumPy 2.5 rewrote `NDArray` as a PEP 695 type alias, which can no longer be used as a base class. `ContinuousArray` in `src/yapss/_private/input_args.py` now subclasses `np.ndarray` directly instead of `NDArray[T]`.
- Advanced mypy 1.13.0 -> 1.20.2 in `tox.ini` and `.pre-commit-config.yaml`, and unified the two mypy environments, which had been silently resolving different NumPy point releases against a `numpy<2.5` range pin:
  - Both environments now pin NumPy to an exact `==2.4.6` (matching how mypy itself is already pinned exact), rather than a range. A range pin let tox and pre-commit resolve different NumPy versions with genuinely different mypy-visible generic typing for `ndarray.copy()`/`__new__()`, producing contradictory errors between the two environments.
  - `tox.ini`'s `[testenv:mypy]` `basepython` moved from `python3.10` to `python3.13` to match the pre-commit hook. NumPy dropped Python 3.10 wheels as of 2.3.0, so a 3.10-hosted env could never resolve past NumPy 2.2.6 regardless of the upper bound. `[tool.mypy] python_version = "3.10"` still governs the actual type-checking target, independent of the tox host Python.
- Fixed the resulting mypy errors: `cast()`/annotated-local wraps for four NumPy-generic-erasing returns in `input_args.py` (`ContinuousArray.__new__`, three `.copy()` properties) and `nlp.py` (`eval_constraints`' `cf.c.copy()`), plus fixes in `solution.py`, `guess.py`, `central_difference.py`, and `dynamic_soaring.py`.
- Fixed 34 `plt.xlim([a, b])` / `plt.ylim([a, b])` call-overload errors across 9 example scripts (list -> tuple args, matching matplotlib's type stubs). No behavior change.
- Moved a stray `Callable` import in `quadrature.py` into the `TYPE_CHECKING` block (ruff TC003), matching the existing `NDArray` pattern.
- Updated `CHANGELOG.md`'s `[Unreleased]` section and `TOOLING_PLAN.md`'s mypy-pins backlog entry.

Runtime NumPy stays pinned `<2.5` in `pyproject.toml` — raising that floor needs `python>=3.12` and is deferred, separate work.

No linked issue; found and fixed during routine mypy/NumPy maintenance.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `tox -e mypy` passes clean under the unified environment
- [x] `pre-commit run --all-files` passes (black, isort, mypy, pytest all rerun via the pre-commit hook for one point in the matrix)
- [x] Full `tox` test suite passes

**Test Configuration**:
* Operating System: (fill in)
* Hardware: (fill in)

## Checklist:

- [x] My code changes are consistent with the style of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes