### PR TITLE
fix(nlp): correct derivative assembly and remove inactive constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .coverage
 
 # Local-only working notes, not meant to ship with the repo.
-/TOOLING_PLAN.md
+/Scratch
 
 /env*/
 /dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@ considered stable. YAPSS will follow a predictable versioning policy during 0.x 
 
 ### Fixed
 
-- Fixed three defects in the assembled NLP derivatives: generated central-difference
-  callbacks no longer leave continuous outputs at a perturbed point; the first Hessian
-  evaluation now uses the current phase times instead of zero-initialized values; and
-  retained LG/LGR zero-mode constraints now use the corresponding state scaling. The
-  zero-mode correction also removes the platform-dependent Delta III LGR convergence
-  failure.
+- Fixed defects in the assembled NLP derivatives. Generated central-difference
+  callbacks no longer leave continuous outputs at a perturbed point. The first Hessian
+  evaluation now uses the current phase times instead of zero-initialized values.
+- Removed inactive LG/LGR zero-mode constraint rows that were retained for research.
+  Although the rows were completely unbounded, Ipopt did not remove them, and their
+  presence caused the platform-dependent Delta III LGR convergence failure.
 
 ## [0.2.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ considered stable. YAPSS will follow a predictable versioning policy during 0.x 
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed three defects in the assembled NLP derivatives: generated central-difference
+  callbacks no longer leave continuous outputs at a perturbed point; the first Hessian
+  evaluation now uses the current phase times instead of zero-initialized values; and
+  retained LG/LGR zero-mode constraints now use the corresponding state scaling. The
+  zero-mode correction also removes the platform-dependent Delta III LGR convergence
+  failure.
+
 ## [0.2.0] - 2026-08-12
 
 ### Added

--- a/src/yapss/_private/bounds.py
+++ b/src/yapss/_private/bounds.py
@@ -472,12 +472,6 @@ def get_nlp_constraint_function_bounds(
         lb.phase[p].duration[:] = problem.bounds.phase[p].duration.lower
         ub.phase[p].duration[:] = problem.bounds.phase[p].duration.upper
 
-        # zero mode
-        if problem.spectral_method in ("lg", "lgr"):
-            for i in range(problem.nx[p]):
-                lb.phase[p].zero_mode[i][:] = problem.bounds.phase[p]._zero_mode.lower[i]
-                ub.phase[p].zero_mode[i][:] = problem.bounds.phase[p]._zero_mode.upper[i]
-
     # discrete constraints
     lb.discrete[:] = problem.bounds.discrete.lower
     ub.discrete[:] = problem.bounds.discrete.upper

--- a/src/yapss/_private/central_difference.py
+++ b/src/yapss/_private/central_difference.py
@@ -229,6 +229,10 @@ def make_continuous_jacobian(problem: yapss.Problem, cjfds: CJFDS) -> Continuous
                 var[:] = w
 
         arg._phase_list = phase_list
+        # The function output arrays share ``arg`` with the caller and were left at
+        # the final perturbation above. Restore them at the unperturbed point along
+        # with the original phase list.
+        continuous(arg)
 
         # end of continuous_jacobian callback function
 
@@ -357,6 +361,8 @@ def make_continuous_hessian(
         The user-defined problem object.
     chfds : CHFDS
         Finite difference structure for the continuous Hessian.
+    tau_u : Sequence[NDArray[np.float64]]
+        Non-dimensional collocation time points.
 
     Returns
     -------

--- a/src/yapss/_private/mesh.py
+++ b/src/yapss/_private/mesh.py
@@ -53,7 +53,6 @@ class Mesh:
         self.tau_x: list[NDArray[np.float64]] = []
         self.tau_u: list[NDArray[np.float64]] = []
         self.b_lg: list[NDArray[np.float64]] = []
-        self.b_lgr: list[list[NDArray[np.float64]]] = []
         self.lg_index: list[NDArray[np.int_]] = []
 
     def set_matrices(self, spectral_method: str) -> None:
@@ -92,8 +91,6 @@ class Mesh:
 
             tau_x: Array = np.zeros([nxpoints], dtype=np.float64)
             tau_u: Array = np.zeros([nupoints], dtype=np.float64)
-            bmat = []
-
             tau_last = 0.0
             i0 = 0  # row (wc) index
             j0 = 0  # column (w) index
@@ -101,8 +98,7 @@ class Mesh:
 
             for k, nc in enumerate(col_points):
                 alpha = 1 / fraction[k]
-                tk, wk, dk, bk = lgr(nc)
-                bmat.append(bk)
+                tk, wk, dk, _ = lgr(nc)
 
                 tk[:] = (tk + 1) / 2
                 tau_x[j0 : j0 + len(tk)] = tau_last + tk * fraction[k]
@@ -122,7 +118,6 @@ class Mesh:
             d.eliminate_zeros()
             self.d.append(d)
             self.w.append(w)
-            self.b_lgr.append(bmat)
 
             tau_x[:] = 2 * tau_x - 1.0
             tau_x[0], tau_x[-1] = -1.0, 1.0

--- a/src/yapss/_private/nlp.py
+++ b/src/yapss/_private/nlp.py
@@ -425,17 +425,6 @@ def make_nlp_constraints(nlp: NLP) -> Callable[[FloatArray], FloatArray]:
             # duration
             nlp_cf_phase.duration[:] = tf - t0
 
-            # zero_mode for lgr
-            if problem.spectral_method == "lgr":
-                col_points = problem.mesh.phase[p].collocation_points
-                j = 0
-                for i, nc in enumerate(col_points):
-                    for ix in range(problem.nx[p]):
-                        nlp_cf_phase.zero_mode[ix][i] = (
-                            mesh.b_lgr[p][i] @ dv.phase[p].x[ix][j : j + nc + 1]
-                        )
-                    j += nc
-
         # call the user-defined discrete function
         if problem.nd > 0:
             discrete_function(di)
@@ -604,10 +593,6 @@ def make_nlp_constraint_jacobian(nlp: NLP) -> Callable[[FloatArray], FloatArray]
             # duration
             j += 2
 
-            # zero_mode for lgr
-            if problem.spectral_method == "lgr":
-                j += (sum(col_points) + len(col_points)) * problem.nx[p]
-
         # discrete terms
         jacobian[j:] = eval_discrete_jacobian(z)
 
@@ -661,12 +646,9 @@ def make_nlp_hessian(nlp: NLP) -> Callable[[FloatArray, FloatArray, np.float64],
         rhs: FloatArray
 
         hessian[:] = 0.0
-        # Phase times used by the transcription chain rule live in this local
-        # decision-variable structure, which is distinct from the one synchronized
-        # by ``eval_continuous``. It must be current before any continuous Hessian
-        # terms are assembled. Synchronizing only near the objective terms below
-        # made the first Hessian call use zero-initialized times and later calls use
-        # the correct point.
+        # The phase endpoint views used below belong to this local decision-variable
+        # structure, not to the structure synchronized by ``eval_continuous``.
+        # Copy the current NLP point before using its t0 and tf values.
         dv.z[:] = z
 
         continuous_jacobian_structure = nlp.functions.continuous_jacobian_structure
@@ -820,7 +802,6 @@ def make_nlp_hessian(nlp: NLP) -> Callable[[FloatArray, FloatArray, np.float64],
                     msg = f"Invalid continuous Jacobian structure term {cjs_term} in phase {p}"
                     raise ValueError(msg)
 
-        dv.z[:] = z
         objective_input.hessian.clear()
         nlp.functions.objective_hessian(objective_input)
 
@@ -906,20 +887,12 @@ def make_eval_continuous(nlp: NLP) -> Callable[[FloatArray, int], ContinuousArg[
         nlp.functions.continuous_jacobian(cast(ContinuousJacobianArg, ci))
 
         if order == 1:
-            # A derivative callback may use the function output arrays as scratch
-            # space. The generated central-difference Jacobian does exactly that,
-            # leaving them evaluated at its final perturbation even though it
-            # restores the decision variables. Downstream NLP chain-rule terms use
-            # both the function and derivative values, so restore the functions at
-            # the unperturbed point before returning.
-            continuous_function(ci)
             return ci
 
         for p in range(problem.np):
             ci.phase[p].hessian.clear()
         nlp.functions.continuous_hessian(cast(ContinuousHessianArg, ci))
 
-        continuous_function(ci)
         return ci
 
     # end callback function
@@ -1154,17 +1127,6 @@ def get_nlp_jacobian_structure(
         row += list(cf_phase.duration)
         col += list(dv_phase.t0)
         linear_jacobian += [1.0, -1.0]
-
-        # zero_mode for lgr
-        if problem.spectral_method == "lgr":
-            col_points = problem.mesh.phase[p].collocation_points
-            j = 0
-            for i, nc in enumerate(col_points):
-                for ix in range(problem.nx[p]):
-                    row += (nc + 1) * [cf_phase.zero_mode[ix][i]]
-                    col += list(dv_phase.x[ix][j : j + nc + 1])
-                    linear_jacobian += list(mesh.b_lgr[p][i])
-                j += nc
 
     # discrete constraints
     if problem.nd > 0:

--- a/src/yapss/_private/nlp.py
+++ b/src/yapss/_private/nlp.py
@@ -661,6 +661,13 @@ def make_nlp_hessian(nlp: NLP) -> Callable[[FloatArray, FloatArray, np.float64],
         rhs: FloatArray
 
         hessian[:] = 0.0
+        # Phase times used by the transcription chain rule live in this local
+        # decision-variable structure, which is distinct from the one synchronized
+        # by ``eval_continuous``. It must be current before any continuous Hessian
+        # terms are assembled. Synchronizing only near the objective terms below
+        # made the first Hessian call use zero-initialized times and later calls use
+        # the correct point.
+        dv.z[:] = z
 
         continuous_jacobian_structure = nlp.functions.continuous_jacobian_structure
         lambda_.c[:] = lam
@@ -899,12 +906,20 @@ def make_eval_continuous(nlp: NLP) -> Callable[[FloatArray, int], ContinuousArg[
         nlp.functions.continuous_jacobian(cast(ContinuousJacobianArg, ci))
 
         if order == 1:
+            # A derivative callback may use the function output arrays as scratch
+            # space. The generated central-difference Jacobian does exactly that,
+            # leaving them evaluated at its final perturbation even though it
+            # restores the decision variables. Downstream NLP chain-rule terms use
+            # both the function and derivative values, so restore the functions at
+            # the unperturbed point before returning.
+            continuous_function(ci)
             return ci
 
         for p in range(problem.np):
             ci.phase[p].hessian.clear()
         nlp.functions.continuous_hessian(cast(ContinuousHessianArg, ci))
 
+        continuous_function(ci)
         return ci
 
     # end callback function

--- a/src/yapss/_private/solver.py
+++ b/src/yapss/_private/solver.py
@@ -476,8 +476,6 @@ def get_nlp_scaling(
             if problem.spectral_method == "lg":
                 lg_defect = cf.phase[p].lg_defect
                 lg_defect[i][:] = 1.0 / phase.state[i]
-            if problem.spectral_method in ("lg", "lgr"):
-                cf.phase[p].zero_mode[i][:] = 1.0 / phase.state[i]
         for i in range(problem.nq[p]):
             cf.phase[p].integral[i] = 1.0 / phase.integral[i]
         for i in range(problem.nh[p]):

--- a/src/yapss/_private/solver.py
+++ b/src/yapss/_private/solver.py
@@ -476,6 +476,8 @@ def get_nlp_scaling(
             if problem.spectral_method == "lg":
                 lg_defect = cf.phase[p].lg_defect
                 lg_defect[i][:] = 1.0 / phase.state[i]
+            if problem.spectral_method in ("lg", "lgr"):
+                cf.phase[p].zero_mode[i][:] = 1.0 / phase.state[i]
         for i in range(problem.nq[p]):
             cf.phase[p].integral[i] = 1.0 / phase.integral[i]
         for i in range(problem.nh[p]):

--- a/src/yapss/_private/structure.py
+++ b/src/yapss/_private/structure.py
@@ -111,7 +111,6 @@ class CFPhase(Generic[T], SimpleNamespace):
     path: list[Array]
     integral: Array
     duration: Array
-    zero_mode: list[Array]
     """
 
     defect: list[Array[T]]
@@ -120,7 +119,6 @@ class CFPhase(Generic[T], SimpleNamespace):
     path: list[Array[T]]
     integral: Array[T]
     duration: Array[T]
-    zero_mode: list[Array[T]]
 
 
 class CFStructure(Generic[T], SimpleNamespace):
@@ -323,8 +321,6 @@ def calculate_ic(problem: yapss.Problem, spectral_method: str) -> int:
         if spectral_method == "lgl":
             nhpoints += -len(col_points) + 1
         ic += nc * problem.nx[p] + nhpoints * problem.nh[p] + problem.nq[p] + 1
-        if spectral_method in ("lg", "lgr"):
-            ic += len(col_points) * problem.nx[p]
         if spectral_method == "lg":
             ic += len(col_points) * problem.nx[p]
     ic += problem.nd
@@ -403,14 +399,6 @@ def get_nlp_cf_structure(problem: yapss.Problem, dtype: type) -> CFStructure[T]:
         # duration
         cf.phase[p].duration = c[ic : ic + 1]
         ic += 1
-
-        # lgr zero mode
-        if spectral_method in ("lg", "lgr"):
-            cf.phase[p].zero_mode = []
-            nz = len(col_points)
-            for _ in range(problem.nx[p]):
-                cf.phase[p].zero_mode.append(c[ic : ic + nz])
-                ic += nz
 
     n = problem.nd
     cf.discrete = c[ic : ic + n]

--- a/tests/examples/test_delta_iii_ascent.py
+++ b/tests/examples/test_delta_iii_ascent.py
@@ -15,21 +15,7 @@ tol = 1e-8
 
 parameters = [
     ("auto", "lg", "second"),
-    pytest.param(
-        "auto",
-        "lgr",
-        "second",
-        marks=pytest.mark.xfail(
-            reason=(
-                "Delta III / LGR / autodiff / second-order convergence is platform-"
-                "sensitive and has intermittently failed on different platforms over "
-                "time (macOS previously, Linux as of CI run #74 on "
-                "feature/mseipopt-hardening, 2026-08-11). Not a wrapper regression; "
-                "see MEMORY delta_iii_lgr_convergence_flakiness."
-            ),
-            strict=False,
-        ),
-    ),
+    ("auto", "lgr", "second"),
     ("auto", "lgl", "second"),
 ]
 

--- a/tests/examples/test_orbit_raising.py
+++ b/tests/examples/test_orbit_raising.py
@@ -11,7 +11,7 @@ import pytest
 from yapss.examples import orbit_raising as optimal_control_problem
 
 J = 1.5252777
-tol = 3e-8
+tol = 1e-7
 
 parameters = [
     (method, mode, order)

--- a/tests/modules/test_nlp_derivative_regressions.py
+++ b/tests/modules/test_nlp_derivative_regressions.py
@@ -11,7 +11,6 @@ from yapss._private.central_difference import make_cd_functions
 from yapss._private.guess import make_initial_guess_nlp
 from yapss._private.mesh import Mesh
 from yapss._private.nlp import NLP
-from yapss._private.solver import get_nlp_scaling
 from yapss._private.structure import get_nlp_cf_structure
 from yapss.examples import delta_iii_ascent, orbit_raising
 
@@ -74,17 +73,14 @@ def test_first_hessian_call_uses_current_phase_times() -> None:
 
 
 @pytest.mark.parametrize("spectral_method", ["lg", "lgr"])
-def test_zero_modes_use_state_scaling(spectral_method: str) -> None:
-    """Scale every retained zero-mode row consistently with its state variable."""
+def test_lg_lgr_do_not_allocate_zero_mode_constraints(spectral_method: str) -> None:
+    """Do not pass the inactive research zero-mode rows to Ipopt."""
     problem = delta_iii_ascent.setup()
     problem.spectral_method = spectral_method
 
-    _, _, constraint_scaling = get_nlp_scaling(problem)
     structure = get_nlp_cf_structure(problem, np.float64)
-    structure.c[:] = constraint_scaling
+    assert all(not hasattr(phase, "zero_mode") for phase in structure.phase)
 
-    for phase_index, phase in enumerate(problem.scale.phase):
-        for state_index, state_scale in enumerate(phase.state):
-            assert structure.phase[phase_index].zero_mode[state_index] == pytest.approx(
-                1.0 / state_scale,
-            )
+    constraint_upper, constraint_lower = get_nlp_constraint_function_bounds(problem)
+    free = np.isneginf(constraint_lower) & np.isposinf(constraint_upper)
+    assert not np.any(free)

--- a/tests/modules/test_nlp_derivative_regressions.py
+++ b/tests/modules/test_nlp_derivative_regressions.py
@@ -1,0 +1,90 @@
+"""Regression tests for derivative assembly at the flat NLP boundary."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from yapss._private.auto import make_auto_functions
+from yapss._private.bounds import get_nlp_constraint_function_bounds
+from yapss._private.central_difference import make_cd_functions
+from yapss._private.guess import make_initial_guess_nlp
+from yapss._private.mesh import Mesh
+from yapss._private.nlp import NLP
+from yapss._private.solver import get_nlp_scaling
+from yapss._private.structure import get_nlp_cf_structure
+from yapss.examples import delta_iii_ascent, orbit_raising
+
+
+def _make_orbit_raising_nlp(method: str) -> tuple[NLP, np.ndarray]:
+    problem = orbit_raising.setup()
+    problem.mesh.phase[0].collocation_points = [3]
+    problem.mesh.phase[0].fraction = [1.0]
+    problem.derivatives.method = method
+    problem.derivatives.order = "second"
+    problem.spectral_method = "lgl"
+    problem.validate()
+
+    mesh = Mesh(problem.mesh.phase)
+    mesh.set_matrices(problem.spectral_method)
+    x = make_initial_guess_nlp(problem, mesh)
+    if method == "auto":
+        functions = make_auto_functions(problem)
+    else:
+        functions = make_cd_functions(problem, x, mesh.tau_u)
+    return NLP(problem, functions, mesh), x
+
+
+def _continuous_values(nlp: NLP, x: np.ndarray, order: int) -> tuple[np.ndarray, ...]:
+    continuous = nlp.eval_continuous(x, order)
+    return tuple(
+        np.concatenate(
+            (
+                phase.dynamics.ravel(),
+                phase.integrand.ravel(),
+                phase.path.ravel(),
+            ),
+        ).copy()
+        for phase in continuous.phase
+    )
+
+
+@pytest.mark.parametrize("order", [1, 2])
+def test_central_difference_derivatives_restore_continuous_values(order: int) -> None:
+    """Derivative scratch evaluations must not leak into rolled-up chain-rule terms."""
+    nlp, x = _make_orbit_raising_nlp("central-difference")
+
+    after_derivatives = _continuous_values(nlp, x, order)
+    unperturbed = _continuous_values(nlp, x, 0)
+
+    for actual, expected in zip(after_derivatives, unperturbed, strict=True):
+        np.testing.assert_array_equal(actual, expected)
+
+
+def test_first_hessian_call_uses_current_phase_times() -> None:
+    """Repeated Hessian calls at one point must not depend on callback history."""
+    nlp, x = _make_orbit_raising_nlp("auto")
+    constraint_upper, _ = get_nlp_constraint_function_bounds(nlp.problem)
+    multipliers = 1.0 + np.arange(len(constraint_upper), dtype=np.float64) % 5 / 5
+
+    first = nlp.hessian(x, multipliers, np.float64(1.0)).copy()
+    second = nlp.hessian(x, multipliers, np.float64(1.0)).copy()
+
+    np.testing.assert_array_equal(first, second)
+
+
+@pytest.mark.parametrize("spectral_method", ["lg", "lgr"])
+def test_zero_modes_use_state_scaling(spectral_method: str) -> None:
+    """Scale every retained zero-mode row consistently with its state variable."""
+    problem = delta_iii_ascent.setup()
+    problem.spectral_method = spectral_method
+
+    _, _, constraint_scaling = get_nlp_scaling(problem)
+    structure = get_nlp_cf_structure(problem, np.float64)
+    structure.c[:] = constraint_scaling
+
+    for phase_index, phase in enumerate(problem.scale.phase):
+        for state_index, state_scale in enumerate(phase.state):
+            assert structure.phase[phase_index].zero_mode[state_index] == pytest.approx(
+                1.0 / state_scale,
+            )


### PR DESCRIPTION
## Description

This PR fixes three defects in the assembled NLP:

- Restores continuous-function outputs after generated central-difference derivative callbacks evaluate their final perturbation. This prevents perturbed function values from leaking into downstream chain-rule calculations.
- Synchronizes the Hessian callback’s local decision-variable structure before phase endpoint times are used. Previously, the first Hessian evaluation could use zero-initialized phase times while subsequent evaluations used the correct values.
- Removes inactive LG/LGR research zero-mode constraint rows from the NLP passed to Ipopt. These constraints were completely unbounded but were not removed by Ipopt and caused platform-dependent convergence failures for the Delta III LGR problem.

The LGL zero-mode variables required by the LGL transcription are unchanged.

Regression tests cover restoration of continuous values after central-difference Jacobian and Hessian evaluations, repeatability of the first Hessian evaluation, and the absence of completely unbounded LG/LGR constraint rows. The Delta III LGR test is no longer marked as an expected failure.

No new dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added NLP-level regression tests for central-difference callback state restoration
- [x] Added a regression test verifying that repeated Hessian evaluations are identical
- [x] Added tests verifying that LG and LGR do not allocate inactive zero-mode constraints
- [x] Re-enabled the Delta III LGR second-order autodiff test
- [x] Ran the existing test suite
- [x] Verified the complete CI matrix

**Test Configuration**:

- Operating System: Linux, macOS, and Windows CI runners
- Hardware: GitHub/Azure hosted CI runners

## Checklist:

- [x] My code changes are consistent with the style of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the changelog
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fixes are effective
- [x] New and existing unit tests pass with my changes