### PR TITLE
ci: change ci.yml so test-conda runs on pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,13 @@ jobs:
           retention-days: 5
 
   # ------------------------------------------------------------- conda ------
-  # Weekly canary only -- not run on push/PR. cyipopt links conda-forge's own
-  # IPOPT build, a materially different path from the pip stack's mseipopt;
-  # nothing else here exercises it.
+  # Run on PRs and as a weekly canary. cyipopt links conda-forge's own IPOPT
+  # build, a materially different path from the pip stack's mseipopt; nothing
+  # else here exercises it.
   test-conda:
     if: >-
-      github.event_name == 'schedule'
+      github.event_name == 'pull_request'
+      || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && contains(fromJSON('["all", "test-conda"]'), inputs.job))
     runs-on: ubuntu-latest
     defaults:
@@ -165,10 +166,10 @@ jobs:
 
   # Weekly canary for conda/environment.yml, the yapss-dev contributor dev
   # environment -- not consumed by any other CI job, so nothing else catches
-  # it drifting out of resolvability. Same weekly/manual-dispatch cadence and
-  # single-platform scope as test-conda above: this checks whether the dev
-  # tooling stack resolves and works, which isn't platform-sensitive the way
-  # solver behavior is, so a 3-machine matrix wouldn't buy much here.
+  # it drifting out of resolvability. This remains a weekly/manual-dispatch
+  # single-platform check: the dev tooling stack isn't platform-sensitive the
+  # way solver behavior is, so running it on every PR or using a 3-machine
+  # matrix wouldn't buy much here.
   test-conda-dev-env:
     if: >-
       github.event_name == 'schedule'


### PR DESCRIPTION
## Description

This PR runs the `test-conda` CI job on every pull request targeting `main`, in addition to its existing weekly and manual triggers.

The conda test exercises `cyipopt` with conda-forge’s IPOPT build, which is materially different from the `mseipopt` path used by pip installations. Previously, this path was not tested before changes were merged.

The heavier `test-conda-dev-env` resolvability check remains weekly/manual.

No new dependencies are required, and there are no user-facing package changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Parsed `.github/workflows/ci.yml` successfully as YAML
- [x] Verified the patch with `git diff --check`
- [ ] Confirmed the `test-conda` job runs successfully on this pull request

**Test Configuration**:

- Operating System: macOS locally; Ubuntu GitHub-hosted runner for `test-conda`
- Hardware: Local development machine and GitHub-hosted runner

## Checklist:

- [x] My code changes are consistent with the style of this project
- [x] I have performed a self-review of my code
- [x] I have updated the workflow comments to describe the trigger policy
- [x] My changes generate no new warnings
- [ ] The conda test passes in pull-request CI

## Remark

The test-conda job is triggered correctly, but the conda test suite does not currently pass.
Enabling the job on this pull request exposed nondeterministic convergence failures in the
Delta III ascent example when using the conda-forge Ipopt/MUMPS backend. (All checks
are shown as passed below because the test-conda job passed on a re-run.)

The workflow change and the example fix are intentionally being kept separate. This pull
request adds the missing conda coverage; a follow-up pull request will address the Delta III
initial-guess weakness exposed by that coverage.